### PR TITLE
Additions for Monitoring Database

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,6 +51,12 @@ services:
       - MYSQL_USER=simplifier
       - MYSQL_PASSWORD=${DB_PASSWORD}
       - MYSQL_DB=${DB_NAME}
+      - MONITORING_DBMS=mysql
+      - MONITORING_DB_HOST=mysql
+      - MONITORING_DB_PORT=3306
+      - MONITORING_DB_USER=simplifier
+      - MONITORING_DB_PASS=${DB_PASSWORD}
+      - MONITORING_DB=${DB_NAME}_monitoring
       - PLUGINLIST=${PLUGINLIST}
       - JVM_PARAMETER=-Xmx${SIMPLIFIER_JVM_HEAP_GB}g -Xms2g -XX:MaxMetaspaceSize=512m -XX:+UseG1GC -XX:+UseStringDeduplication -XX:-UseGCOverheadLimit -Xss256m
       - SECOND_SEED=${INSTANCE_PREFIX}-launchpad

--- a/mysql/config.yaml
+++ b/mysql/config.yaml
@@ -11,3 +11,4 @@ databases:
   - ${DB_PREFIX}_jsonstore
   - ${DB_PREFIX}_wf_rt
   - ${DB_PREFIX}_wf_dt
+  - ${DB_PREFIX}_monitoring


### PR DESCRIPTION
Adding the environment configurations for the monitoring databse.
As default configuration, we have set up the database "simplifier_monitoring", located on the same database server as the main simplifer database.